### PR TITLE
Removed aliases of builtin types like np.int (deprecated)

### DIFF
--- a/demo01_similarity.py
+++ b/demo01_similarity.py
@@ -68,7 +68,7 @@ spk_sim_matrix = np.inner(spk_embeds_a, spk_embeds_b)
 fix, axs = plt.subplots(2, 2, figsize=(8, 10))
 labels_a = ["%s-A" % i for i in speaker_wavs.keys()]
 labels_b = ["%s-B" % i for i in speaker_wavs.keys()]
-mask = np.eye(len(utt_sim_matrix), dtype=np.bool)
+mask = np.eye(len(utt_sim_matrix), dtype=bool)
 plot_similarity_matrix(utt_sim_matrix, labels_a, labels_b, axs[0, 0],
                        "Cross-similarity between utterances\n(speaker_id-utterance_group)")
 plot_histograms((utt_sim_matrix[mask], utt_sim_matrix[np.logical_not(mask)]), axs[0, 1],

--- a/demo03_projection.py
+++ b/demo03_projection.py
@@ -16,7 +16,7 @@ import numpy as np
 ## Gather the wavs
 wav_fpaths = list(Path("audio_data", "librispeech_test-other").glob("**/*.flac"))
 speakers = list(map(lambda wav_fpath: wav_fpath.parent.stem, wav_fpaths))
-wavs = np.array(list(map(preprocess_wav, tqdm(wav_fpaths, "Preprocessing wavs", len(wav_fpaths)))))
+wavs = np.array(list(map(preprocess_wav, tqdm(wav_fpaths, "Preprocessing wavs", len(wav_fpaths)))), dtype=object)
 speaker_wavs = {speaker: wavs[list(indices)] for speaker, indices in 
                 groupby(range(len(wavs)), lambda i: speakers[i])}
 

--- a/demo05_fake_speech_detection.py
+++ b/demo05_fake_speech_detection.py
@@ -34,7 +34,7 @@ names = np.array([fpath.stem for fpath in wav_fpaths])
 
 # Take 6 real embeddings at random, and leave the 6 others for testing
 gt_indices = np.random.choice(*np.where(speakers == "real"), 6, replace=False) 
-mask = np.zeros(len(embeds), dtype=np.bool)
+mask = np.zeros(len(embeds), dtype=bool)
 mask[gt_indices] = True
 gt_embeds = embeds[mask]
 gt_names = names[mask]

--- a/demo_utils.py
+++ b/demo_utils.py
@@ -24,7 +24,7 @@ _my_colors = np.array([
     [0, 0, 0],
     [183, 183, 183],
     [76, 255, 0],
-], dtype=np.float) / 255 
+], dtype=float) / 255
 
 
 def play_wav(wav, blocking=True):

--- a/requirements_demos.txt
+++ b/requirements_demos.txt
@@ -1,5 +1,5 @@
 librosa>=0.9.1
-numpy>=1.10.1
+numpy>=1.20.0
 webrtcvad>=2.0.10
 torch>=1.0.1
 scipy>=1.2.1

--- a/requirements_package.txt
+++ b/requirements_package.txt
@@ -1,5 +1,5 @@
 librosa>=0.9.1
-numpy>=1.10.1
+numpy>=1.20.0
 webrtcvad>=2.0.10
 torch>=1.0.1
 scipy>=1.2.1

--- a/resemblyzer/audio.py
+++ b/resemblyzer/audio.py
@@ -88,7 +88,7 @@ def trim_long_silences(wav):
         return ret[width - 1:] / width
     
     audio_mask = moving_average(voice_flags, vad_moving_average_width)
-    audio_mask = np.round(audio_mask).astype(np.bool)
+    audio_mask = np.round(audio_mask).astype(bool)
     
     # Dilate the voiced regions
     audio_mask = binary_dilation(audio_mask, np.ones(vad_max_silence_length + 1))


### PR DESCRIPTION
Updated codebase to remove Numpy builtin aliases.

Using the aliases of builtin types like np.int is deprecated (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)