### PR TITLE
Fix unsafe `torch.load` by adding `weights_only=True`

### DIFF
--- a/resemblyzer/voice_encoder.py
+++ b/resemblyzer/voice_encoder.py
@@ -40,7 +40,7 @@ class VoiceEncoder(nn.Module):
             raise Exception("Couldn't find the voice encoder pretrained model at %s." %
                             weights_fpath)
         start = timer()
-        checkpoint = torch.load(weights_fpath, map_location="cpu")
+        checkpoint = torch.load(weights_fpath, map_location="cpu", weights_only=True)
         self.load_state_dict(checkpoint["model_state"], strict=False)
         self.to(device)
 


### PR DESCRIPTION
### Fix Description: Resemblyzer Unsafe Pickle Loading Mitigation

In version 0.1.4 of Resemblyzer, the use of `torch.load()` without explicitly setting `weights_only=True` can expose users to potential risks when loading pickled files. Pickle files can execute arbitrary code during deserialization, leading to security vulnerabilities, and current versions of `torch` warn about this.

To address this, I modified Resemblyzer's `voice_encoder.py` to enforce safer loading practices. Specifically, we updated the `torch.load()` calls to include the parameter `weights_only=True`, ensuring that only model weights are loaded without executing untrusted code.

This modification secures the file loading process and mitigates the risks associated with untrusted data deserialization. The change was made directly in the codebase without using external scripts to patch the system.

**Details of the Change:**
- **File:** `voice_encoder.py`
- **Version:** Resemblyzer 0.1.4
- **Modification:** Added `weights_only=True` to all `torch.load()` calls that previously lacked this parameter.
  
FYI: Since the currently implemented `torch.load()` method is considered unsafe, I've been using an automated code patching script for my [whisper-transcriber-telegram-bot](https://github.com/FlyingFathead/whisper-transcriber-telegram-bot/) when it comes to loading Resemblyzer-related stuff. Should someone need to patch their v0.1.4, the script I made is [here](https://github.com/FlyingFathead/whisper-transcriber-telegram-bot/blob/main/src/utils/resemblyzer_safety_check.py). I haven't experienced any bugs or glitches when using the `weights_only=True` load method in my own application.